### PR TITLE
Add tsconfig and main entrypoint for Netlify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+dist/
 .env

--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -1,32 +1,8 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Twitter, MessageCircle, Send, Users, Activity, Trophy } from 'lucide-react';
+import { Users, Activity, Trophy } from 'lucide-react';
 
 const Community: React.FC = () => {
-  const socialLinks = [
-    {
-      name: "Twitter",
-      icon: <Twitter className="w-8 h-8" />,
-      followers: "25.4K",
-      link: "#",
-      color: "hover:text-blue-400"
-    },
-    {
-      name: "Discord",
-      icon: <MessageCircle className="w-8 h-8" />,
-      followers: "18.2K",
-      link: "#",
-      color: "hover:text-purple-400"
-    },
-    {
-      name: "Telegram",
-      icon: <Send className="w-8 h-8" />,
-      followers: "32.1K",
-      link: "#",
-      color: "hover:text-blue-500"
-    }
-  ];
-
   const communityStats = [
     {
       icon: <Users className="w-8 h-8" />,
@@ -93,35 +69,6 @@ const Community: React.FC = () => {
             </motion.div>
           ))}
         </div>
-
-        {/* Social Links */}
-        <div className="grid md:grid-cols-3 gap-8 mb-16">
-          {socialLinks.map((social, index) => (
-            <motion.a
-              key={index}
-              href={social.link}
-              initial={{ opacity: 0, y: 50 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: index * 0.1 }}
-              viewport={{ once: true }}
-              className={`glass-card p-8 rounded-xl text-center hover:scale-105 transition-all duration-300 ${social.color} group`}
-            >
-              <div className="text-white group-hover:scale-110 transition-transform duration-300 mb-4 flex justify-center">
-                {social.icon}
-              </div>
-              <h3 className="text-xl font-bold text-white mb-2">
-                {social.name}
-              </h3>
-              <p className="text-2xl font-black text-electric-blue mb-2">
-                {social.followers}
-              </p>
-              <p className="text-gray-400 text-sm">
-                Followers
-              </p>
-            </motion.a>
-          ))}
-        </div>
-
         {/* Newsletter Signup */}
         <motion.div
           initial={{ opacity: 0, y: 50 }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -30,12 +30,7 @@ const Footer: React.FC = () => {
             viewport={{ once: true }}
             className="md:col-span-2"
           >
-            <div className="flex items-center space-x-3 mb-4">
-              <img 
-                src="https://24vzlu2kzs.ufs.sh/f/4JlBnp1v6U48k8uO4IDmleihCX1jUIwbvFKds0kp6Aug7WrS" 
-                alt="FRSHMEME Logo" 
-                className="w-10 h-10 rounded-full"
-              />
+            <div className="mb-4">
               <span className="text-2xl font-bold neon-text">$FRSHMEME</span>
             </div>
             <p className="text-gray-300 mb-4 max-w-md">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,17 +19,12 @@ const Header: React.FC = () => {
     <header className="fixed top-0 left-0 right-0 z-50 glass-card">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
-          <motion.div 
-            className="flex items-center space-x-3"
+          <motion.div
+            className="flex items-center"
             initial={{ opacity: 0, x: -20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <img 
-              src="https://24vzlu2kzs.ufs.sh/f/4JlBnp1v6U48k8uO4IDmleihCX1jUIwbvFKds0kp6Aug7WrS" 
-              alt="FRSHMEME Logo" 
-              className="w-10 h-10 rounded-full"
-            />
             <span className="text-2xl font-bold neon-text">$FRSHMEME</span>
           </motion.div>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,11 +20,17 @@ const Hero: React.FC = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
         >
-          <img 
-            src="https://24vzlu2kzs.ufs.sh/f/4JlBnp1v6U48k8uO4IDmleihCX1jUIwbvFKds0kp6Aug7WrS" 
-            alt="FRSHMEME Logo" 
-            className="w-32 h-32 mx-auto mb-8 rounded-full animate-pulse-glow"
-          />
+          <a
+            href="https://freshmemes.online"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              src="https://24vzlu2kzs.ufs.sh/f/4JlBnp1v6U48k8uO4IDmleihCX1jUIwbvFKds0kp6Aug7WrS"
+              alt="FRSHMEME Logo"
+              className="w-32 h-32 mx-auto mb-8 rounded-full animate-pulse-glow"
+            />
+          </a>
           
           <h1 className="text-4xl md:text-7xl font-black mb-6">
             <span className="neon-text">$FRSHMEME</span>

--- a/src/components/Tokenomics.tsx
+++ b/src/components/Tokenomics.tsx
@@ -1,8 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Coins, Users, Flame, Lock } from 'lucide-react';
+import {
+  Coins,
+  Users,
+  Flame,
+  Lock,
+  ArrowUpRight,
+  ArrowDownRight,
+} from 'lucide-react';
 
 const Tokenomics: React.FC = () => {
+  const [price, setPrice] = useState(1);
+  const [change, setChange] = useState<{ percent: number; up: boolean }>({
+    percent: 0,
+    up: true,
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const up = Math.random() > 0.5;
+      const percent = up
+        ? Math.random() * (7265423 - 7) + 7
+        : Math.random() * (32 - 7) + 7;
+      const multiplier = up ? 1 + percent / 100 : 1 - percent / 100;
+      setPrice((prev) => prev * multiplier);
+      setChange({ percent, up });
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
   const tokenStats = [
     {
       icon: <Coins className="w-8 h-8" />,
@@ -53,6 +79,38 @@ const Tokenomics: React.FC = () => {
           </h2>
           <p className="text-xl text-gray-300 max-w-4xl mx-auto">
             Transparent and sustainable token economics designed for long-term growth and community rewards.
+          </p>
+        </motion.div>
+
+        {/* Live Price */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true }}
+          className="mb-12 text-center"
+        >
+          <p className="text-gray-300">Live $FRSHMEME Price</p>
+          <div className="flex items-center justify-center space-x-2">
+            <span className="text-4xl font-extrabold text-white">
+              $
+              {price.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+              })}
+            </span>
+            {change.up ? (
+              <ArrowUpRight className="w-6 h-6 text-neon-green" />
+            ) : (
+              <ArrowDownRight className="w-6 h-6 text-red-500" />
+            )}
+          </div>
+          <p
+            className={`text-lg font-bold ${
+              change.up ? 'text-neon-green' : 'text-red-500'
+            }`}
+          >
+            {change.up ? '+' : '-'}
+            {change.percent.toFixed(2)}%
           </p>
         </motion.div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap');
 
 * {
   margin: 0;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add comprehensive TypeScript configuration
- add React `main.tsx` entry point and ignore build artefacts
- center clickable hero logo, drop social follower grid, and remove redundant header/footer logos
- introduce live `$FRSHMEME` price ticker with random meme-like swings

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689947b62df88323adf65de49adf0ccc