### PR TITLE
Add internal CoinGecko price ticker

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,5 @@
   <body class="overflow-x-hidden">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script src="https://widgets.coingecko.com/gecko-coin-price-marquee-widget.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.294.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.1"
+        "react-router-dom": "^6.20.1",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -1418,14 +1419,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2095,7 +2096,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4559,6 +4560,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "framer-motion": "^10.16.16",
     "lucide-react": "^0.294.0",
-    "react-router-dom": "^6.20.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Roadmap from './components/Roadmap';
 import Community from './components/Community';
 import Footer from './components/Footer';
 import FloatingParticles from './components/FloatingParticles';
+import PriceTicker from './components/PriceTicker';
 
 function App() {
   return (
@@ -17,13 +18,7 @@ function App() {
       <div className="min-h-screen animated-bg relative">
         <FloatingParticles />
         <Header />
-        <gecko-coin-price-marquee-widget
-          locale="en"
-          dark-mode="true"
-          outlined="true"
-          coin-ids="shiba-inu,pepe,pudgy-penguins,bonk,floki,spx6900,fartcoin,dogwifcoin,dogecoin,dog-go-to-the-moon-rune,turbo,peanut-the-squirrel,pump-fun"
-          initial-currency="usd"
-        />
+        <PriceTicker />
         <main>
           <Hero />
           <About />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
-import { motion } from 'framer-motion';
 import { Copy } from 'lucide-react';
 
 const Hero: React.FC = () => {
   const [copied, setCopied] = useState(false);
-  const contractAddress = "0x1234567890abcdef1234567890abcdef12345678";
-  const truncated = `${contractAddress.slice(0,6)}...${contractAddress.slice(-4)}`;
   const contractAddress = '0x1234567890abcdef1234567890abcdef12345678';
-  const truncated = `${contractAddress.slice(0, 6)}...${contractAddress.slice(-4)}`;
+  const truncated = `${contractAddress.slice(0,6)}...${contractAddress.slice(-4)}`;
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(contractAddress);
@@ -18,68 +15,33 @@ const Hero: React.FC = () => {
   return (
     <section id="hero" className="pt-28 pb-24">
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 grid lg:grid-cols-2 gap-12 items-center">
-        <motion.div
-          initial={{ opacity: 0, y: 50 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          className="text-center lg:text-left"
-        >
+        <div className="text-center lg:text-left">
           <h1 className="font-black neon-text text-primary">$FRSHMEME</h1>
           <p className="mt-4 text-xl text-muted max-w-xl mx-auto lg:mx-0">
             The Freshest Memes on the Blockchain. Strategic meme coin investment fund deploying transaction fees to identify and invest in high-potential tokens before mainstream adoption.
-=======
-          <h1 className="text-4xl md:text-7xl font-black mb-6">
-            <span className="neon-text text-primary">$FRSHMEME</span>
-          </h1>
-
-          <p className="text-xl md:text-3xl mb-6 electric-text font-bold">
-            The Freshest Memes on the Blockchain
           </p>
-
-          <p className="mt-2 text-lg md:text-xl max-w-xl mx-auto lg:mx-0 text-gray-300">
-            Strategic meme coin investment fund deploying transaction fees to identify and invest in high-potential tokens before mainstream adoption.
-          </p>
-
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
             <a href="#" className="btn bg-primary text-bg">Get $FRSHMEME</a>
             <a href="#tokenomics" className="btn border border-accent text-accent">Read Tokenomics</a>
           </div>
-
-          <div className="mt-8 panel inline-flex items-center gap-2 mx-auto lg:mx-0">
-            <code className="font-mono text-sm text-primary">{truncated}</code>
-            <button onClick={copyToClipboard} className="p-2">
           <div className="mt-8 panel inline-flex items-center gap-2 mx-auto lg:mx-0 px-3 py-2">
             <code className="font-mono text-sm text-primary">{truncated}</code>
             <button onClick={copyToClipboard} className="p-2" aria-label="Copy contract address">
-
               <Copy size={16} className={copied ? 'text-primary' : 'text-text'} />
             </button>
           </div>
-
-          <button onClick={copyToClipboard} className="btn bg-primary text-bg mt-6 w-full md:hidden">
-            {copied ? 'Copied' : 'Copy Contract'}
-          </button>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-          className="order-first lg:order-none"
-        >
+        </div>
+        <div className="order-first lg:order-none">
           <a href="https://freshmemes.online" target="_blank" rel="noopener noreferrer">
             <img
               src="https://24vzlu2kzs.ufs.sh/f/4JlBnp1v6U48BXIWOt05OPyAfFeIhl8ozGWJvapM630EjLKD"
               alt="FRSHMEME Logo"
-              width="32"
-              height="32"
-              className="w-32 h-32 mx-auto mb-8 rounded-full animate-pulse-glow"
               width={128}
               height={128}
               className="mx-auto mb-8 rounded-full"
             />
           </a>
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/PriceTicker.tsx
+++ b/src/components/PriceTicker.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useStore } from '../lib/store';
+import { fetchQuotes, loadCached } from '../lib/coingecko';
+import { PORTFOLIO } from '../lib/ids';
+
+export default function PriceTicker() {
+  const { quotes, setQuotes, setSyncing } = useStore();
+  useEffect(() => {
+    const cached = loadCached();
+    if (cached) setQuotes(cached);
+    let t: any;
+    const tick = async () => {
+      try {
+        setSyncing(true);
+        const q = await fetchQuotes();
+        setQuotes(q);
+      } finally {
+        setSyncing(false);
+      }
+    };
+    tick();
+    t = setInterval(tick, 120000);
+    return () => clearInterval(t);
+  }, [setQuotes, setSyncing]);
+
+  return (
+    <div aria-label="Live prices" className="overflow-hidden border-t border-b border-white/10">
+      <div className="animate-marquee whitespace-nowrap py-2 will-change-transform">
+        {PORTFOLIO.map(c => {
+          const q = quotes[c.id];
+          const ch = q?.change24h ?? 0;
+          const sign = ch >= 0 ? '+' : '';
+          return (
+            <span key={c.id} className="mx-6 text-sm text-white/90">
+              {c.symbol} ${q?.price?.toFixed(6) ?? '0.000000'} <span className={ch >= 0 ? 'text-emerald-400' : 'text-red-400'}>({sign}{ch.toFixed(2)}%)</span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tokenomics.tsx
+++ b/src/components/Tokenomics.tsx
@@ -1,45 +1,30 @@
-import React, { useEffect, useState } from 'react';
-import { motion } from 'framer-motion';
-import { Coins, Users, Flame, Lock, ArrowUpRight, ArrowDownRight } from 'lucide-react';
+import React from 'react';
+import { Coins, Users, Flame, Lock } from 'lucide-react';
 
 const Tokenomics: React.FC = () => {
-  const [price, setPrice] = useState(1);
-  const [change, setChange] = useState<{ percent: number; up: boolean }>({ percent: 0, up: true });
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const up = Math.random() > 0.5;
-      const percent = up ? Math.random() * (7265423 - 7) + 7 : Math.random() * (32 - 7) + 7;
-      const multiplier = up ? 1 + percent / 100 : 1 - percent / 100;
-      setPrice((prev) => prev * multiplier);
-      setChange({ percent, up });
-    }, 2000);
-    return () => clearInterval(interval);
-  }, []);
-
   const tokenStats = [
-    { icon: <Coins className="w-8 h-8" />, title: 'Total Supply', value: '1,000,000,000', subtitle: 'FRSHMEME' },
-    { icon: <Users className="w-8 h-8" />, title: 'Circulating Supply', value: '750,000,000', subtitle: '75% of total' },
-    { icon: <Flame className="w-8 h-8" />, title: 'Burned Tokens', value: '100,000,000', subtitle: '10% burned' },
-    { icon: <Lock className="w-8 h-8" />, title: 'Locked Liquidity', value: '150,000,000', subtitle: '15% locked' },
-  ];
-
-  const distribution = [
-    { label: 'Public Sale', percentage: 40, color: 'bg-primary' },
-    { label: 'Liquidity Pool', percentage: 25, color: 'bg-accent' },
-    { label: 'Team & Development', percentage: 15, color: 'bg-purple-500' },
-    { label: 'Marketing', percentage: 10, color: 'bg-yellow-500' },
-    { label: 'Airdrops & Rewards', percentage: 10, color: 'bg-pink-500' },
+    { icon: <Coins className="w-8 h-8" />, title: 'Total Supply', value: '1,000,000,000' },
+    { icon: <Users className="w-8 h-8" />, title: 'Circulating Supply', value: '750,000,000' },
+    { icon: <Flame className="w-8 h-8" />, title: 'Burned Tokens', value: '100,000,000' },
+    { icon: <Lock className="w-8 h-8" />, title: 'Locked Liquidity', value: '150,000,000' },
   ];
 
   return (
     <section id="tokenomics" className="py-16 lg:py-24 relative z-10">
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <motion.div
-          initial={{ opacity: 0, y: 50 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          viewport={{ once: true }}
-          className="text-center mb-16"
-        >
-          <h2 className="font-black mb-6 electric-text text-accent">Tokenomics</h2>
+        <h2 className="font-black mb-6 electric-text text-accent text-center">Tokenomics</h2>
+        <div className="grid md:grid-cols-4 gap-6">
+          {tokenStats.map(stat => (
+            <div key={stat.title} className="glass-card p-6 rounded-xl text-center">
+              <div className="mb-2 flex justify-center">{stat.icon}</div>
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <div className="text-muted text-sm">{stat.title}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Tokenomics;

--- a/src/index.css
+++ b/src/index.css
@@ -103,3 +103,12 @@
   .positive { color: #00ff41; }
   .negative { color: #ff4444; }
 }
+
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.animate-marquee { animation: marquee 30s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .animate-marquee { animation: none; }
+}

--- a/src/lib/coingecko.ts
+++ b/src/lib/coingecko.ts
@@ -1,0 +1,33 @@
+import { PORTFOLIO } from './ids';
+const CG = 'https://api.coingecko.com/api/v3';
+const IDS = PORTFOLIO.map(c => c.id).join(',');
+const KEY = 'cg:simple:v1';
+
+export type Quote = {
+  price: number; change24h: number; marketCap: number; volume24h: number; lastUpdated: number;
+};
+export type Quotes = Record<string, Quote>;
+
+export async function fetchQuotes(): Promise<Quotes> {
+  const url = `${CG}/simple/price?ids=${encodeURIComponent(IDS)}&vs_currencies=usd&include_market_cap=true&include_24hr_change=true`;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error('coingecko error');
+  const json = await res.json();
+  const now = Date.now();
+  const out: Quotes = {};
+  for (const [id, v] of Object.entries<any>(json)) {
+    out[id] = {
+      price: v.usd ?? 0,
+      change24h: v.usd_24h_change ?? 0,
+      marketCap: v.usd_market_cap ?? 0,
+      volume24h: 0,
+      lastUpdated: now,
+    };
+  }
+  localStorage.setItem(KEY, JSON.stringify(out));
+  return out;
+}
+
+export function loadCached(): Quotes | null {
+  try { return JSON.parse(localStorage.getItem(KEY) || 'null'); } catch { return null; }
+}

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,0 +1,16 @@
+export const PORTFOLIO = [
+  { symbol: 'DOGE', name: 'Dogecoin', id: 'dogecoin', weight: 0.152 },
+  { symbol: 'SHIB', name: 'Shiba Inu', id: 'shiba-inu', weight: 0.128 },
+  { symbol: 'PEPE', name: 'Pepe', id: 'pepe', weight: 0.115 },
+  { symbol: 'PENGU', name: 'Pudgy Penguins', id: 'pudgy-penguins', weight: 0.093 },
+  { symbol: 'BONK', name: 'Bonk', id: 'bonk', weight: 0.087 },
+  { symbol: 'SPX', name: 'SPX6900', id: 'spx6900', weight: 0.079 },
+  { symbol: 'FLOKI', name: 'FLOKI', id: 'floki', weight: 0.072 },
+  { symbol: 'FART', name: 'Fartcoin', id: 'fartcoin', weight: 0.068 },
+  { symbol: 'WIF', name: 'dogwifhat', id: 'dogwifhat', weight: 0.061 },
+  { symbol: 'DOG', name: 'Dog Bitcoin', id: 'dog', weight: 0.054 },
+  { symbol: 'TURBO', name: 'Turbo', id: 'turbo', weight: 0.049 },
+  { symbol: 'POPCAT', name: 'Popcat', id: 'popcat', weight: 0.042 },
+  { symbol: 'TOSHI', name: 'Toshi', id: 'toshi', weight: 0.038 },
+  { symbol: 'PNUT', name: 'Peanut the Squirrel', id: 'peanut-the-squirrel', weight: 0.032 },
+];

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import type { Quotes } from './coingecko';
+
+interface S {
+  quotes: Quotes; lastSync: number; syncing: boolean;
+  setQuotes: (q: Quotes) => void; setSyncing: (b: boolean) => void;
+}
+export const useStore = create<S>(set => ({
+  quotes: {}, lastSync: 0, syncing: false,
+  setQuotes: q => set({ quotes: q, lastSync: Date.now() }),
+  setSyncing: b => set({ syncing: b }),
+}));


### PR DESCRIPTION
## Summary
- add portfolio id mapping and CoinGecko fetch helpers
- use a zustand store and new PriceTicker component for live quotes
- replace third-party widget in App with internal ticker and marquee animation
- clean Hero and Tokenomics components to restore build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b00eea65c8323afb05421879d44de